### PR TITLE
Eventin lisäys kalenteriin

### DIFF
--- a/backend/groups/serializers.py
+++ b/backend/groups/serializers.py
@@ -18,6 +18,9 @@ class EventSerializer(serializers.ModelSerializer):
     class Meta:
         model = Event
         fields = '__all__'
+        extra_kwargs = {
+            'created_by': {'read_only': True},
+        }
 
 class GroupSerializer(serializers.ModelSerializer):
     events = EventSerializer(many=True, read_only=True)

--- a/backend/groups/urls.py
+++ b/backend/groups/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import (
     GroupListCreateView, GroupDetailView,
     GroupMembershipListCreateView, GroupMembershipDetailView,
-    EventListCreateView, EventDetailView
+    EventListCreateView, EventDetailView, EventCreateView
 )
 
 urlpatterns = [
@@ -12,4 +12,5 @@ urlpatterns = [
     path('memberships/<int:pk>/', GroupMembershipDetailView.as_view(), name='membership-detail'),
     path('events/', EventListCreateView.as_view(), name='event-list-create'),
     path('events/<int:pk>/', EventDetailView.as_view(), name='event-detail'),
+    path('events/create/', EventCreateView.as_view(), name='event-create'),
 ]

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -4,6 +4,9 @@ from django.db import models
 from .serializers import GroupSerializer, GroupMembershipSerializer, EventSerializer
 from rest_framework.response import Response
 from rest_framework import status
+import logging
+
+logger = logging.getLogger(__name__)
 
 class GroupListCreateView(generics.ListCreateAPIView):
     serializer_class = GroupSerializer
@@ -40,3 +43,11 @@ class EventListCreateView(generics.ListCreateAPIView):
 class EventDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Event.objects.all()
     serializer_class = EventSerializer
+
+class EventCreateView(generics.CreateAPIView):
+    queryset = Event.objects.all()
+    serializer_class = EventSerializer
+
+    def perform_create(self, serializer):
+        logger.debug(f"Creating event with data: {serializer.validated_data}")
+        serializer.save(created_by=self.request.user)

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: WelcomeScreen(),
+      home: const WelcomeScreen(),
     );
   }
 }

--- a/frontend/lib/screens/calendar_screen.dart
+++ b/frontend/lib/screens/calendar_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
 
 class CalendarScreen extends StatelessWidget {
+  const CalendarScreen({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -9,7 +11,7 @@ class CalendarScreen extends StatelessWidget {
       body: SfCalendar(
         view: CalendarView.month,
         dataSource: MeetingDataSource(_getDataSource()),
-        monthViewSettings: MonthViewSettings(
+        monthViewSettings: const MonthViewSettings(
           appointmentDisplayMode: MonthAppointmentDisplayMode.appointment,
         ),
       ),

--- a/frontend/lib/screens/create_event_screen.dart
+++ b/frontend/lib/screens/create_event_screen.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import '../services/group_service.dart';
+
+class CreateEventScreen extends StatefulWidget {
+  final String token;
+  final int groupId;
+
+  const CreateEventScreen(
+      {Key? key, required this.token, required this.groupId})
+      : super(key: key);
+
+  @override
+  _CreateEventScreenState createState() => _CreateEventScreenState();
+}
+
+class _CreateEventScreenState extends State<CreateEventScreen> {
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  DateTime _startTime = DateTime.now();
+  DateTime _endTime = DateTime.now().add(const Duration(hours: 1));
+  final GroupService _groupService = GroupService();
+
+  Future<void> _createEvent() async {
+    try {
+      final success = await _groupService.createEvent(
+        widget.token,
+        widget.groupId,
+        _titleController.text,
+        _descriptionController.text,
+        _startTime,
+        _endTime,
+      );
+
+      if (success) {
+        if (mounted) {
+          Navigator.pop(context);
+        }
+      } else {
+        _showErrorDialog('Failed to create event. Please try again.');
+      }
+    } catch (e) {
+      debugPrint('Error creating event: $e');
+      _showErrorDialog('An error occurred. Please try again.');
+    }
+  }
+
+  void _showErrorDialog(String message) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Error'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Event')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'Event Title'),
+            ),
+            TextField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(labelText: 'Description'),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              children: [
+                const Text('Start Time:'),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  onPressed: () async {
+                    final pickedDate = await showDatePicker(
+                      context: context,
+                      initialDate: _startTime,
+                      firstDate: DateTime(2000),
+                      lastDate: DateTime(2101),
+                    );
+                    if (pickedDate != null) {
+                      final pickedTime = await showTimePicker(
+                        context: context,
+                        initialTime: TimeOfDay.fromDateTime(_startTime),
+                      );
+                      if (pickedTime != null) {
+                        setState(() {
+                          _startTime = DateTime(
+                            pickedDate.year,
+                            pickedDate.month,
+                            pickedDate.day,
+                            pickedTime.hour,
+                            pickedTime.minute,
+                          );
+                        });
+                      }
+                    }
+                  },
+                  child: Text('${_startTime.toLocal()}'.split(' ')[0]),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                const Text('End Time:'),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  onPressed: () async {
+                    final pickedDate = await showDatePicker(
+                      context: context,
+                      initialDate: _endTime,
+                      firstDate: DateTime(2000),
+                      lastDate: DateTime(2101),
+                    );
+                    if (pickedDate != null) {
+                      final pickedTime = await showTimePicker(
+                        context: context,
+                        initialTime: TimeOfDay.fromDateTime(_endTime),
+                      );
+                      if (pickedTime != null) {
+                        setState(() {
+                          _endTime = DateTime(
+                            pickedDate.year,
+                            pickedDate.month,
+                            pickedDate.day,
+                            pickedTime.hour,
+                            pickedTime.minute,
+                          );
+                        });
+                      }
+                    }
+                  },
+                  child: Text('${_endTime.toLocal()}'.split(' ')[0]),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _createEvent,
+              child: const Text('Create Event'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/create_group_screen.dart
+++ b/frontend/lib/screens/create_group_screen.dart
@@ -4,7 +4,7 @@ import '../services/group_service.dart';
 class CreateGroupScreen extends StatefulWidget {
   final String token;
 
-  CreateGroupScreen({required this.token});
+  const CreateGroupScreen({super.key, required this.token});
 
   @override
   _CreateGroupScreenState createState() => _CreateGroupScreenState();
@@ -32,23 +32,23 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Create Group')),
+      appBar: AppBar(title: const Text('Create Group')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
             TextField(
               controller: _nameController,
-              decoration: InputDecoration(labelText: 'Group Name'),
+              decoration: const InputDecoration(labelText: 'Group Name'),
             ),
             TextField(
               controller: _descriptionController,
-              decoration: InputDecoration(labelText: 'Description'),
+              decoration: const InputDecoration(labelText: 'Description'),
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             ElevatedButton(
               onPressed: _createGroup,
-              child: Text('Create'),
+              child: const Text('Create'),
             ),
           ],
         ),

--- a/frontend/lib/screens/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
 import '../services/group_service.dart';
+import 'create_event_screen.dart';
 
 class GroupDetailScreen extends StatefulWidget {
   final String token;
@@ -27,14 +28,11 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
     try {
       final fetchedGroup =
           await _groupService.fetchGroupDetails(widget.token, widget.groupId);
-      print('Fetched group: $fetchedGroup'); // Debugging statement
       setState(() {
         group = fetchedGroup;
-        events = fetchedGroup['events'] ?? []; // Handle missing events
-        print('Fetched events: $events'); // Debugging statement
+        events = fetchedGroup['events'] ?? [];
       });
     } catch (e) {
-      print('Error fetching group details: $e'); // Debugging statement
       // Handle error
     }
   }
@@ -42,7 +40,25 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(group?['name'] ?? 'Group Details')),
+      appBar: AppBar(
+        title: Text(group?['name'] ?? 'Group Details'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.add),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => CreateEventScreen(
+                    token: widget.token,
+                    groupId: widget.groupId,
+                  ),
+                ),
+              ).then((_) => fetchGroupDetails());
+            },
+          ),
+        ],
+      ),
       body: group == null
           ? Center(child: CircularProgressIndicator())
           : Column(

--- a/frontend/lib/screens/group_screen.dart
+++ b/frontend/lib/screens/group_screen.dart
@@ -6,7 +6,7 @@ import 'create_group_screen.dart';
 class GroupScreen extends StatefulWidget {
   final String token;
 
-  GroupScreen({required this.token});
+  const GroupScreen({super.key, required this.token});
 
   @override
   _GroupScreenState createState() => _GroupScreenState();
@@ -37,10 +37,10 @@ class _GroupScreenState extends State<GroupScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Groups'),
+        title: const Text('Groups'),
         actions: [
           IconButton(
-            icon: Icon(Icons.add),
+            icon: const Icon(Icons.add),
             onPressed: () {
               Navigator.push(
                 context,

--- a/frontend/lib/screens/logged_in_screen.dart
+++ b/frontend/lib/screens/logged_in_screen.dart
@@ -12,7 +12,7 @@ class LoggedInScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Navigate to the group screen after 3 seconds with a fade transition
-    Timer(Duration(seconds: 3), () {
+    Timer(const Duration(seconds: 3), () {
       Navigator.pushReplacement(
         context,
         PageRouteBuilder(
@@ -38,22 +38,22 @@ class LoggedInScreen extends StatelessWidget {
             children: [
               Text(
                 'Welcome $username!',
-                style: TextStyle(
+                style: const TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              SizedBox(height: 20),
-              Text(
+              const SizedBox(height: 20),
+              const Text(
                 'Your token is:',
                 style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.w500,
                 ),
               ),
-              SizedBox(height: 10),
+              const SizedBox(height: 10),
               Container(
-                padding: EdgeInsets.all(8.0),
+                padding: const EdgeInsets.all(8.0),
                 decoration: BoxDecoration(
                   color: Colors.grey[200],
                   borderRadius: BorderRadius.circular(8.0),
@@ -61,7 +61,7 @@ class LoggedInScreen extends StatelessWidget {
                 child: Text(
                   token,
                   textAlign: TextAlign.center,
-                  style: TextStyle(
+                  style: const TextStyle(
                     fontSize: 16,
                     fontFamily: 'Courier',
                   ),

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -3,6 +3,8 @@ import '../services/auth_service.dart';
 import 'logged_in_screen.dart';
 
 class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
   @override
   _LoginScreenState createState() => _LoginScreenState();
 }
@@ -20,7 +22,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
     if (result != null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Login successful!')),
+        const SnackBar(content: Text('Login successful!')),
       );
       Navigator.pushReplacement(
         context,
@@ -33,7 +35,7 @@ class _LoginScreenState extends State<LoginScreen> {
       );
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Login failed.')),
+        const SnackBar(content: Text('Login failed.')),
       );
     }
   }
@@ -41,24 +43,24 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Login')),
+      appBar: AppBar(title: const Text('Login')),
       body: Padding(
-        padding: EdgeInsets.all(16.0),
+        padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
             TextField(
               controller: _usernameController,
-              decoration: InputDecoration(labelText: 'Username'),
+              decoration: const InputDecoration(labelText: 'Username'),
             ),
             TextField(
               controller: _passwordController,
-              decoration: InputDecoration(labelText: 'Password'),
+              decoration: const InputDecoration(labelText: 'Password'),
               obscureText: true,
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             ElevatedButton(
               onPressed: _login,
-              child: Text('Login'),
+              child: const Text('Login'),
             ),
           ],
         ),

--- a/frontend/lib/screens/welcome_screen.dart
+++ b/frontend/lib/screens/welcome_screen.dart
@@ -17,7 +17,8 @@ class WelcomeScreen extends StatelessWidget {
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => RegisterScreen()),
+                  MaterialPageRoute(
+                      builder: (context) => const RegisterScreen()),
                 );
               },
               child: const Text('Register'),

--- a/frontend/lib/services/group_service.dart
+++ b/frontend/lib/services/group_service.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter/foundation.dart';
 
 class GroupService {
   final String baseUrl = dotenv.env['BASE_URL']!;
@@ -75,8 +76,11 @@ class GroupService {
 
   Future<bool> createEvent(String token, int groupId, String title,
       String description, DateTime startTime, DateTime endTime) async {
+    final url = Uri.parse('$baseUrl/groups/events/create/');
+    debugPrint(
+        'Sending POST request to $url with data: {group: $groupId, title: $title, description: $description, start_time: ${startTime.toIso8601String()}, end_time: ${endTime.toIso8601String()}}');
     final response = await http.post(
-      Uri.parse('$baseUrl/events/'),
+      url,
       headers: {
         'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
@@ -91,9 +95,10 @@ class GroupService {
     );
 
     if (response.statusCode == 201) {
+      debugPrint('Event created successfully');
       return true;
     } else {
-      print('Failed to create event: ${response.body}');
+      debugPrint('Failed to create event: ${response.body}');
       return false;
     }
   }


### PR DESCRIPTION
Closes #7 

**Backend:**

- Lisätty `EventCreateView` ja vastaava URL-polku tapahtuman luontia varten. `(backend/groups/urls.py)`
- Päivitetty `EventSerializer` merkitsemään `created_by` vain luku -kentäksi. `(backend/groups/serializers.py)`
- Toteutettu `perform_create`-metodi EventCreateView-luokassa tapahtuman luomisen lokittamiseksi ja created_by-kentän asettamiseksi. `(backend/groups/views.py)`

**Frontend:**

- Lisätty uusi `CreateEventScreen`-näkymä tapahtuman luontia varten. `(frontend/lib/screens/create_event_screen.dart)`
- Päivitetty `GroupDetailScreen` sisältämään painikkeen, joka ohjaa `CreateEventScreen`-näkymään. `(frontend/lib/screens/group_detail_screen.dart)`