### PR TITLE
Poista kalenteriryhmä

### DIFF
--- a/backend/groups/urls.py
+++ b/backend/groups/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from .views import (
-    GroupListCreateView, GroupDetailView, GroupMembersView,
+    DeleteGroupView, GroupListCreateView, GroupDetailView, GroupMembersView,
     GroupMembershipListCreateView, GroupMembershipDetailView,
     EventListCreateView, EventDetailView, EventCreateView, InviteUserView, AcceptInvitationView, KickUserView, RejectInvitationView, ListInvitationsView
 )
@@ -8,6 +8,7 @@ from .views import (
 urlpatterns = [
     path('', GroupListCreateView.as_view(), name='group-list-create'),
     path('<int:pk>/', GroupDetailView.as_view(), name='group-detail'),
+    path('<int:pk>/delete/', DeleteGroupView.as_view(), name='delete-group'),
     path('memberships/', GroupMembershipListCreateView.as_view(), name='membership-list-create'),
     path('memberships/<int:pk>/', GroupMembershipDetailView.as_view(), name='membership-detail'),
     path('events/', EventListCreateView.as_view(), name='event-list-create'),

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -34,12 +34,17 @@ class GroupDetailView(generics.RetrieveUpdateDestroyAPIView):
         group = self.get_object()
         serializer = self.get_serializer(group)
         return Response(serializer.data)
+    
+class DeleteGroupView(generics.DestroyAPIView):
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
 
     def delete(self, request, *args, **kwargs):
         group = self.get_object()
         if group.created_by != request.user:
             return Response({'error': 'Only the group admin can delete the group.'}, status=status.HTTP_403_FORBIDDEN)
-        return super().delete(request, *args, **kwargs)
+        group.delete()
+        return Response({'message': 'Group deleted successfully'}, status=status.HTTP_204_NO_CONTENT)
     
 class KickUserView(generics.DestroyAPIView):
     queryset = GroupMembership.objects.all()

--- a/frontend/lib/screens/group_screen.dart
+++ b/frontend/lib/screens/group_screen.dart
@@ -75,8 +75,8 @@ class _GroupScreenState extends State<GroupScreen> {
             title: Text(groups[index]['name']),
             trailing: IconButton(
               icon: const Icon(Icons.settings),
-              onPressed: () {
-                Navigator.push(
+              onPressed: () async {
+                final result = await Navigator.push(
                   context,
                   MaterialPageRoute(
                     builder: (context) => GroupSettingsScreen(
@@ -85,6 +85,9 @@ class _GroupScreenState extends State<GroupScreen> {
                     ),
                   ),
                 );
+                if (result == true) {
+                  fetchGroups(); // Refresh groups if a group was deleted
+                }
               },
             ),
             onTap: () {

--- a/frontend/lib/screens/group_settings_screen.dart
+++ b/frontend/lib/screens/group_settings_screen.dart
@@ -6,7 +6,8 @@ class GroupSettingsScreen extends StatefulWidget {
   final int groupId;
 
   const GroupSettingsScreen(
-      {super.key, required this.token, required this.groupId});
+      {Key? key, required this.token, required this.groupId})
+      : super(key: key);
 
   @override
   _GroupSettingsScreenState createState() => _GroupSettingsScreenState();
@@ -53,15 +54,15 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
       final success = await _groupService.inviteUser(
           widget.token, widget.groupId, _emailController.text);
       if (success) {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('User invited successfully')));
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('User invited successfully')));
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Failed to invite user')));
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Failed to invite user')));
       }
     } catch (e) {
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('An error occurred')));
+          .showSnackBar(SnackBar(content: Text('An error occurred')));
     }
   }
 
@@ -70,16 +71,62 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
       final success = await _groupService.kickUser(widget.token, membershipId);
       if (success) {
         fetchGroupDetails();
-        ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('User kicked successfully')));
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('User kicked successfully')));
       } else {
         ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Failed to kick user')));
+            .showSnackBar(SnackBar(content: Text('Failed to kick user')));
       }
     } catch (e) {
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('An error occurred')));
+          .showSnackBar(SnackBar(content: Text('An error occurred')));
     }
+  }
+
+  Future<void> _deleteGroup() async {
+    try {
+      final success =
+          await _groupService.deleteGroup(widget.token, widget.groupId);
+      if (success) {
+        Navigator.of(context).pop(true);
+        ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Group deleted successfully')));
+      } else {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Failed to delete group')));
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('An error occurred')));
+    }
+  }
+
+  void _showDeleteGroupDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Delete Group'),
+          content: Text(
+              'Are you sure you want to delete this group? This action cannot be undone.'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _deleteGroup();
+              },
+              child: Text('Delete'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   void _showKickUserDialog() async {
@@ -91,8 +138,8 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: const Text('Kick User from Group'),
-          content: SizedBox(
+          title: Text('Kick User from Group'),
+          content: Container(
             width: double.maxFinite,
             child: ListView.builder(
               shrinkWrap: true,
@@ -102,7 +149,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                 return ListTile(
                   title: Text(member['user']['username']),
                   trailing: IconButton(
-                    icon: const Icon(Icons.remove_circle),
+                    icon: Icon(Icons.remove_circle),
                     onPressed: () {
                       Navigator.of(context).pop();
                       _confirmKickUser(
@@ -118,7 +165,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
               onPressed: () {
                 Navigator.of(context).pop();
               },
-              child: const Text('Close'),
+              child: Text('Close'),
             ),
           ],
         );
@@ -131,7 +178,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: const Text('Confirm Kick User'),
+          title: Text('Confirm Kick User'),
           content:
               Text('Are you sure you want to kick $username from the group?'),
           actions: [
@@ -139,14 +186,14 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
               onPressed: () {
                 Navigator.of(context).pop();
               },
-              child: const Text('Cancel'),
+              child: Text('Cancel'),
             ),
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop();
                 _kickUser(membershipId);
               },
-              child: const Text('Kick'),
+              child: Text('Kick'),
             ),
           ],
         );
@@ -159,36 +206,34 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
     final isAdmin = group?['created_by']['id'] == _groupService.currentUserId;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Group Settings')),
+      appBar: AppBar(title: Text('Group Settings')),
       body: group == null
-          ? const Center(child: CircularProgressIndicator())
+          ? Center(child: CircularProgressIndicator())
           : Padding(
               padding: const EdgeInsets.all(16.0),
               child: Column(
                 children: [
                   TextField(
                     controller: _emailController,
-                    decoration: const InputDecoration(labelText: 'Email'),
+                    decoration: InputDecoration(labelText: 'Email'),
                   ),
-                  const SizedBox(height: 20),
+                  SizedBox(height: 20),
                   ElevatedButton(
                     onPressed: _inviteUser,
-                    child: const Text('Invite User'),
+                    child: Text('Invite User'),
                   ),
                   if (isAdmin) ...[
-                    const SizedBox(height: 20),
+                    SizedBox(height: 20),
                     ElevatedButton(
                       onPressed: _showKickUserDialog,
-                      child: const Text('Kick User'),
+                      child: Text('Kick User'),
                     ),
-                    const SizedBox(height: 20),
+                    SizedBox(height: 20),
                     ElevatedButton(
-                      onPressed: () {
-                        // Add delete group functionality
-                      },
-                      child: const Text('Delete Group'),
+                      onPressed: _showDeleteGroupDialog,
+                      child: Text('Delete Group'),
                     ),
-                    const SizedBox(height: 20),
+                    SizedBox(height: 20),
                     Expanded(
                       child: ListView.builder(
                         itemCount: members.length,
@@ -197,7 +242,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
                           return ListTile(
                             title: Text(member['user']['username']),
                             trailing: IconButton(
-                              icon: const Icon(Icons.remove_circle),
+                              icon: Icon(Icons.remove_circle),
                               onPressed: () => _kickUser(member['id']),
                             ),
                           );

--- a/frontend/lib/services/group_service.dart
+++ b/frontend/lib/services/group_service.dart
@@ -241,4 +241,22 @@ class GroupService {
       throw Exception('Failed to load current user details');
     }
   }
+
+  Future<bool> deleteGroup(String token, int groupId) async {
+    final url = Uri.parse('$baseUrl/groups/$groupId/delete/');
+    final response = await http.delete(
+      url,
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 204) {
+      debugPrint('Group deleted successfully');
+      return true;
+    } else {
+      debugPrint('Failed to delete group: ${response.body}');
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
Closes #16 

Tämä pull request sisältää muutoksia, jotka mahdollistavat ryhmän poistamisen sekä siihen liittyvien tietojen, kuten käyttäjien ja tapahtumien, poistamisen tietokannasta. Muutokset kattavat sekä backend- että frontend-komponentit.

**Backend:**

- **Lisätty ryhmän poistamisen toiminnallisuus:** Lisätty DeleteGroupView, joka sisältää delete-metodin, joka poistaa ryhmän ja siihen liittyvät tiedot tietokannasta. **(backend/groups/views.py)**
- **URL-reititys:** Lisätty uusi endpoint `'<int:pk>/delete/'`. (`backend/groups/urls.py)`

**Frontend:**

- **Ryhmäasetukset-näyttö:** Lisätty "Delete Group" -painike, joka avaa vahvistusdialogin ennen ryhmän poistamista. `(frontend/lib/screens/group_settings_screen.dart)`
- **Navigoinnin tulosten käsittely:** Päivitetty GroupSettingsScreen palauttamaan tulos, kun ryhmä poistetaan, ja GroupScreen päivittämään ryhmälistan tämän tuloksen perusteella. `(frontend/lib/screens/group_screen.dart)`