### PR TITLE
Uusi ryhmäkutsu näkyy punaisena pallona

### DIFF
--- a/backend/groups/urls.py
+++ b/backend/groups/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import (
     DeleteGroupView, GroupListCreateView, GroupDetailView, GroupMembersView,
     GroupMembershipListCreateView, GroupMembershipDetailView,
-    EventListCreateView, EventDetailView, EventCreateView, InviteUserView, AcceptInvitationView, KickUserView, RejectInvitationView, ListInvitationsView
+    EventListCreateView, EventDetailView, EventCreateView, InviteUserView, AcceptInvitationView, KickUserView, NewInvitationsCountView, RejectInvitationView, ListInvitationsView
 )
 
 urlpatterns = [
@@ -20,4 +20,5 @@ urlpatterns = [
     path('invitations/', ListInvitationsView.as_view(), name='list-invitations'),
     path('kick/<int:pk>/', KickUserView.as_view(), name='kick-user'),
     path('<int:pk>/members/', GroupMembersView.as_view(), name='group-members'),
+    path('invitations/count/', NewInvitationsCountView.as_view(), name='new-invitations-count'),
 ]

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -6,6 +6,7 @@ from .serializers import GroupSerializer, GroupMembershipSerializer, EventSerial
 from rest_framework.response import Response
 import logging
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
 
 logger = logging.getLogger(__name__)
 
@@ -154,3 +155,11 @@ class GroupMembersView(generics.ListAPIView):
     def get_queryset(self):
         group_id = self.kwargs['pk']
         return GroupMembership.objects.filter(group_id=group_id)
+    
+class NewInvitationsCountView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+        new_invitations_count = GroupInvitation.objects.filter(user=user, accepted=False).count()
+        return Response({'new_invitations_count': new_invitations_count})

--- a/frontend/lib/screens/group_screen.dart
+++ b/frontend/lib/screens/group_screen.dart
@@ -17,11 +17,13 @@ class GroupScreen extends StatefulWidget {
 class _GroupScreenState extends State<GroupScreen> {
   List<dynamic> groups = [];
   final GroupService _groupService = GroupService();
+  int newInvitationsCount = 0;
 
   @override
   void initState() {
     super.initState();
     fetchGroups();
+    fetchNewInvitationsCount();
   }
 
   Future<void> fetchGroups() async {
@@ -29,6 +31,17 @@ class _GroupScreenState extends State<GroupScreen> {
       final fetchedGroups = await _groupService.fetchGroups(widget.token);
       setState(() {
         groups = fetchedGroups;
+      });
+    } catch (e) {
+      // Handle error
+    }
+  }
+
+  Future<void> fetchNewInvitationsCount() async {
+    try {
+      final count = await _groupService.fetchNewInvitationsCount(widget.token);
+      setState(() {
+        newInvitationsCount = count;
       });
     } catch (e) {
       // Handle error
@@ -52,19 +65,49 @@ class _GroupScreenState extends State<GroupScreen> {
               ).then((_) => fetchGroups());
             },
           ),
-          IconButton(
-            icon: const Icon(Icons.mail),
-            onPressed: () async {
-              final result = await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => InvitationsScreen(token: widget.token),
+          Stack(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.mail),
+                onPressed: () async {
+                  final result = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) =>
+                          InvitationsScreen(token: widget.token),
+                    ),
+                  );
+                  if (result == true) {
+                    fetchGroups();
+                    fetchNewInvitationsCount(); // Refresh the count after checking invitations
+                  }
+                },
+              ),
+              if (newInvitationsCount > 0)
+                Positioned(
+                  right: 11,
+                  top: 11,
+                  child: Container(
+                    padding: const EdgeInsets.all(2),
+                    decoration: BoxDecoration(
+                      color: Colors.red,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    constraints: const BoxConstraints(
+                      minWidth: 14,
+                      minHeight: 14,
+                    ),
+                    child: Text(
+                      '$newInvitationsCount',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 8,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
                 ),
-              );
-              if (result == true) {
-                fetchGroups();
-              }
-            },
+            ],
           ),
         ],
       ),

--- a/frontend/lib/services/group_service.dart
+++ b/frontend/lib/services/group_service.dart
@@ -259,4 +259,21 @@ class GroupService {
       return false;
     }
   }
+
+  Future<int> fetchNewInvitationsCount(String token) async {
+    final url = Uri.parse('$baseUrl/groups/invitations/count/');
+    final response = await http.get(
+      url,
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body);
+      return data['new_invitations_count'];
+    } else {
+      throw Exception('Failed to load new invitations count');
+    }
+  }
 }


### PR DESCRIPTION
Closes #11

Tämä pull request lisää uuden ominaisuuden, joka näyttää käyttäjälle uusien kutsujen määrän ryhmänäkymässä. Muutokset kattavat sekä backend- että frontend-koodin tämän toiminnallisuuden tukemiseksi. Tärkeimmät muutokset sisältävät uuden näkymän lisäämisen uusien kutsujen määrän hakemiseksi, URL-mallien päivittämisen sisältämään tämä uusi endpoint sekä frontendin muokkaamisen määrän näyttämiseksi.

### Backend:

* `backend/groups/urls.py`: Lisätty uusi URL-malli `NewInvitationsCountView`-näkymälle uusien kutsujen määrän hakemiseksi.
* `backend/groups/views.py`: Lisätty `NewInvitationsCountView`, joka käsittelee autentikoidun käyttäjän uusien kutsujen määrän hakemisen logiikan.

### Frontend:

* `frontend/lib/screens/group_screen.dart`: Muokattu ryhmänäkymää hakemaan ja näyttämään uusien kutsujen määrä. Tämä sisältää tilan päivittämisen määrän tallentamiseksi, metodin lisäämisen määrän hakemiseksi sekä ilmoitusmerkin näyttämisen kirjekuori-ikonissa, kun uusia kutsuja on.
* `frontend/lib/services/group_service.dart`: Lisätty uusi metodi `fetchNewInvitationsCount`, joka kutsuu backend-endpointia ja hakee uusien kutsujen määrän.