### PR TITLE
JWToken tulee rekisteröityessä

### DIFF
--- a/frontend/lib/screens/register_screen.dart
+++ b/frontend/lib/screens/register_screen.dart
@@ -17,24 +17,25 @@ class _RegisterScreenState extends State<RegisterScreen> {
   final TextEditingController _password2Controller = TextEditingController();
 
   Future<void> _register() async {
-    bool success = await _authService.registerUser(
+    final result = await _authService.registerUser(
       _emailController.text,
       _usernameController.text,
       _passwordController.text,
       _password2Controller.text,
     );
 
-    if (success) {
+    if (result != null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Registration successful!')),
       );
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-            builder: (context) => LoggedInScreen(
-                token: 'dummy_token',
-                username: _usernameController
-                    .text)), // Replace with actual token if needed
+          builder: (context) => LoggedInScreen(
+            username: result['username']!,
+            token: result['token']!,
+          ),
+        ),
       );
     } else {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/frontend/lib/services/auth_service.dart
+++ b/frontend/lib/services/auth_service.dart
@@ -5,7 +5,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 class AuthService {
   final String baseUrl = dotenv.env['BASE_URL']!;
 
-  Future<bool> registerUser(
+  Future<Map<String, String>?> registerUser(
       String email, String username, String password, String password2) async {
     final response = await http.post(
       Uri.parse('$baseUrl/accounts/register/'),
@@ -17,7 +17,12 @@ class AuthService {
       },
     );
 
-    return response.statusCode == 201;
+    if (response.statusCode == 201) {
+      // Automatically log in the user after successful registration
+      return await loginUser(username, password);
+    } else {
+      return null;
+    }
   }
 
   Future<Map<String, String>?> loginUser(


### PR DESCRIPTION
Closes #28 

* `frontend/lib/services/auth_service.dart`: Muokattu `registerUser`-metodia palauttamaan `Map<String, String>?`, joka sisältää käyttäjätiedot onnistuneen rekisteröinnin jälkeen ja kirjautumaan automaattisesti käyttäjän sisään.

Päivitykset rekisteröintinäyttöön:

* `frontend/lib/screens/register_screen.dart`: Päivitetty `_register`-metodia käsittelemään `registerUser`-metodin uutta palautustyyppiä ja käyttämään palautettuja käyttäjätietoja siirtyäkseen `LoggedInScreen`-näyttöön.