### PR TITLE
Kirjekuoren notification fix & Ryhmä Screen päivitys

### DIFF
--- a/frontend/lib/screens/group_screen.dart
+++ b/frontend/lib/screens/group_screen.dart
@@ -171,41 +171,47 @@ class _GroupScreenState extends State<GroupScreen> {
           ),
         ],
       ),
-      body: ListView.builder(
-        itemCount: groups.length,
-        itemBuilder: (context, index) {
-          return ListTile(
-            title: Text(groups[index]['name']),
-            trailing: IconButton(
-              icon: const Icon(Icons.settings),
-              onPressed: () async {
-                final result = await Navigator.push(
+      body: RefreshIndicator(
+        onRefresh: () async {
+          await fetchGroups();
+          await fetchNewInvitationsCount();
+        },
+        child: ListView.builder(
+          itemCount: groups.length,
+          itemBuilder: (context, index) {
+            return ListTile(
+              title: Text(groups[index]['name']),
+              trailing: IconButton(
+                icon: const Icon(Icons.settings),
+                onPressed: () async {
+                  final result = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => GroupSettingsScreen(
+                        token: widget.token,
+                        groupId: groups[index]['id'],
+                      ),
+                    ),
+                  );
+                  if (result == true) {
+                    fetchGroups(); // Refresh groups if a group was deleted
+                  }
+                },
+              ),
+              onTap: () {
+                Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => GroupSettingsScreen(
+                    builder: (context) => GroupDetailScreen(
                       token: widget.token,
                       groupId: groups[index]['id'],
                     ),
                   ),
                 );
-                if (result == true) {
-                  fetchGroups(); // Refresh groups if a group was deleted
-                }
               },
-            ),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => GroupDetailScreen(
-                    token: widget.token,
-                    groupId: groups[index]['id'],
-                  ),
-                ),
-              );
-            },
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }

--- a/frontend/lib/screens/invitations_screen.dart
+++ b/frontend/lib/screens/invitations_screen.dart
@@ -67,6 +67,7 @@ class _InvitationsScreenState extends State<InvitationsScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Invitation rejected')),
         );
+        Navigator.pop(context, true);
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Failed to reject invitation')),


### PR DESCRIPTION
Closes #29 
Closes #39 

### Parannukset käyttäjäkokemukseen:
- **frontend/lib/screens/group_screen.dart**: Lisätty RefreshIndicator GroupScreeniin, joka mahdollistaa pull-to-refresh-toiminnon. Tämä kutsuu fetchGroups- ja fetchNewInvitationsCount-menetelmiä päivittääkseen tiedot.

- **frontend/lib/screens/invitations_screen.dart**: Päivitetty InvitationsScreen navigoimaan takaisin edelliselle näytölle onnistuneen kutsun hylkäämisen jälkeen, tarjoten välitöntä palautetta käyttäjälle.