### PR TITLE
Homescreen näkymän uudistukset

### DIFF
--- a/frontend/lib/screens/group_screen.dart
+++ b/frontend/lib/screens/group_screen.dart
@@ -9,12 +9,13 @@ import '../services/group_service.dart';
 import 'group_detail_screen.dart';
 import 'create_group_screen.dart';
 import 'group_settings_screen.dart';
-import 'invitations_screen.dart';
 
 class GroupScreen extends StatefulWidget {
   final String token;
+  final Function(int) updateInvitationCount;
 
-  const GroupScreen({super.key, required this.token});
+  const GroupScreen(
+      {super.key, required this.token, required this.updateInvitationCount});
 
   @override
   _GroupScreenState createState() => _GroupScreenState();
@@ -102,6 +103,7 @@ class _GroupScreenState extends State<GroupScreen> {
       final count = await _groupService.fetchNewInvitationsCount(widget.token);
       setState(() {
         newInvitationsCount = count;
+        widget.updateInvitationCount(count);
       });
     } catch (e) {
       // Handle error
@@ -113,105 +115,68 @@ class _GroupScreenState extends State<GroupScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Groups'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.add),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (context) =>
-                        CreateGroupScreen(token: widget.token)),
-              ).then((_) => fetchGroups());
-            },
-          ),
-          Stack(
-            children: [
-              IconButton(
-                icon: const Icon(Icons.mail),
-                onPressed: () async {
-                  final result = await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) =>
-                          InvitationsScreen(token: widget.token),
-                    ),
-                  );
-                  if (result == true) {
-                    fetchGroups();
-                    fetchNewInvitationsCount(); // Refresh the count after checking invitations
-                  }
-                },
-              ),
-              if (newInvitationsCount > 0)
-                Positioned(
-                  right: 11,
-                  top: 11,
-                  child: Container(
-                    padding: const EdgeInsets.all(2),
-                    decoration: BoxDecoration(
-                      color: Colors.red,
-                      borderRadius: BorderRadius.circular(6),
-                    ),
-                    constraints: const BoxConstraints(
-                      minWidth: 14,
-                      minHeight: 14,
-                    ),
-                    child: Text(
-                      '$newInvitationsCount',
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 8,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ),
-            ],
-          ),
-        ],
       ),
-      body: RefreshIndicator(
-        onRefresh: () async {
-          await fetchGroups();
-          await fetchNewInvitationsCount();
-        },
-        child: ListView.builder(
-          itemCount: groups.length,
-          itemBuilder: (context, index) {
-            return ListTile(
-              title: Text(groups[index]['name']),
-              trailing: IconButton(
-                icon: const Icon(Icons.settings),
-                onPressed: () async {
-                  final result = await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => GroupSettingsScreen(
-                        token: widget.token,
-                        groupId: groups[index]['id'],
-                      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: RefreshIndicator(
+              onRefresh: () async {
+                await fetchGroups();
+                await fetchNewInvitationsCount();
+              },
+              child: ListView.builder(
+                itemCount: groups.length,
+                itemBuilder: (context, index) {
+                  return ListTile(
+                    title: Text(groups[index]['name']),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.settings),
+                      onPressed: () async {
+                        final result = await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => GroupSettingsScreen(
+                              token: widget.token,
+                              groupId: groups[index]['id'],
+                            ),
+                          ),
+                        );
+                        if (result == true) {
+                          fetchGroups(); // Refresh groups if a group was deleted
+                        }
+                      },
                     ),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => GroupDetailScreen(
+                            token: widget.token,
+                            groupId: groups[index]['id'],
+                          ),
+                        ),
+                      );
+                    },
                   );
-                  if (result == true) {
-                    fetchGroups(); // Refresh groups if a group was deleted
-                  }
                 },
               ),
-              onTap: () {
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: ElevatedButton(
+              onPressed: () {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => GroupDetailScreen(
-                      token: widget.token,
-                      groupId: groups[index]['id'],
-                    ),
-                  ),
-                );
+                      builder: (context) =>
+                          CreateGroupScreen(token: widget.token)),
+                ).then((_) => fetchGroups());
               },
-            );
-          },
-        ),
+              child: const Text('New Calendar Group'),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/frontend/lib/screens/invitations_screen.dart
+++ b/frontend/lib/screens/invitations_screen.dart
@@ -3,8 +3,10 @@ import '../services/group_service.dart';
 
 class InvitationsScreen extends StatefulWidget {
   final String token;
+  final Function(int) updateInvitationCount;
 
-  const InvitationsScreen({super.key, required this.token});
+  const InvitationsScreen(
+      {super.key, required this.token, required this.updateInvitationCount});
 
   @override
   _InvitationsScreenState createState() => _InvitationsScreenState();
@@ -41,11 +43,14 @@ class _InvitationsScreenState extends State<InvitationsScreen> {
       final success =
           await _groupService.acceptInvitation(widget.token, invitationId);
       if (success) {
-        fetchInvitations();
+        setState(() {
+          invitations
+              .removeWhere((invitation) => invitation['id'] == invitationId);
+        });
+        widget.updateInvitationCount(invitations.length);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Invitation accepted')),
         );
-        Navigator.pop(context, true);
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Failed to accept invitation')),
@@ -63,11 +68,14 @@ class _InvitationsScreenState extends State<InvitationsScreen> {
       final success =
           await _groupService.rejectInvitation(widget.token, invitationId);
       if (success) {
-        fetchInvitations();
+        setState(() {
+          invitations
+              .removeWhere((invitation) => invitation['id'] == invitationId);
+        });
+        widget.updateInvitationCount(invitations.length);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Invitation rejected')),
         );
-        Navigator.pop(context, true);
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Failed to reject invitation')),

--- a/frontend/lib/screens/logged_in_screen.dart
+++ b/frontend/lib/screens/logged_in_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'dart:async';
-import 'group_screen.dart';
+import '../widgets/navigation_widget.dart';
 
 class LoggedInScreen extends StatelessWidget {
   final String username;
@@ -16,13 +16,13 @@ class LoggedInScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Navigate to the group screen after 3 seconds with a fade transition
+    // Navigate to the navigation widget after 3 seconds with a fade transition
     Timer(const Duration(seconds: 3), () {
       Navigator.pushReplacement(
         context,
         PageRouteBuilder(
           pageBuilder: (context, animation, secondaryAnimation) =>
-              GroupScreen(token: token),
+              NavigationWidget(token: token),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             return FadeTransition(
               opacity: animation,

--- a/frontend/lib/widgets/navigation_widget.dart
+++ b/frontend/lib/widgets/navigation_widget.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import '../screens/group_screen.dart';
+import '../screens/invitations_screen.dart';
+
+class NavigationWidget extends StatefulWidget {
+  final String token;
+
+  const NavigationWidget({super.key, required this.token});
+
+  @override
+  _NavigationWidgetState createState() => _NavigationWidgetState();
+}
+
+class _NavigationWidgetState extends State<NavigationWidget> {
+  int _selectedIndex = 0;
+  int newInvitationsCount = 0;
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  void updateInvitationCount(int count) {
+    setState(() {
+      newInvitationsCount = count;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> _screens = [
+      GroupScreen(
+          token: widget.token, updateInvitationCount: updateInvitationCount),
+      InvitationsScreen(
+          token: widget.token, updateInvitationCount: updateInvitationCount),
+    ];
+
+    return Scaffold(
+      body: _screens[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        items: <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.group),
+            label: 'Groups',
+          ),
+          BottomNavigationBarItem(
+            icon: Stack(
+              children: [
+                Icon(Icons.notifications),
+                if (newInvitationsCount > 0)
+                  Positioned(
+                    right: 0,
+                    child: Container(
+                      padding: const EdgeInsets.all(2),
+                      decoration: BoxDecoration(
+                        color: Colors.red,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      constraints: const BoxConstraints(
+                        minWidth: 14,
+                        minHeight: 14,
+                      ),
+                      child: Text(
+                        '$newInvitationsCount',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 8,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            label: 'Notifications',
+          ),
+        ],
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Closes #42 

Tämä pull request sisältää merkittäviä muutoksia sovelluksen navigointiin ja kutsujen määrän hallintaan. Keskeiset muutokset sisältävät LoggedInScreen-navigoinnin korvaamisen uudella NavigationWidget-komponentilla, GroupScreen- ja InvitationsScreen-näkymien päivittämisen kutsujen määrän käsittelyyn sekä käyttöliittymän refaktoroinnin näitä päivityksiä varten.

**Navigointi ja kutsujen määrän hallinta:**
- **frontend/lib/screens/logged_in_screen.dart**: Päivitetty navigoimaan NavigationWidget-komponenttiin GroupScreenin sijaan viiveen jälkeen.
- **frontend/lib/widgets/navigation_widget.dart**: Luotu uusi NavigationWidget, joka hallitsee navigointia GroupScreen- ja InvitationsScreen-näkymien välillä ja näyttää kutsujen määrän.

**Päivitykset GroupScreen-näkymään:**
- **frontend/lib/screens/group_screen.dart**: Lisätty `updateInvitationCount`-parametri ja päivitetty käyttöliittymää sisältämään painike uusien kalenteriryhmien luomiseksi.

**Päivitykset InvitationsScreen-näkymään:**
- **frontend/lib/screens/invitations_screen.dart**: Lisätty `updateInvitationCount`-parametri ja päivitetty logiikka poistamaan kutsuja listalta sekä päivittämään määrä hyväksynnän tai hylkäyksen yhteydessä.