### PR TITLE
Top Navbar

### DIFF
--- a/frontend/lib/screens/group_screen.dart
+++ b/frontend/lib/screens/group_screen.dart
@@ -9,6 +9,7 @@ import '../services/group_service.dart';
 import 'group_detail_screen.dart';
 import 'create_group_screen.dart';
 import 'group_settings_screen.dart';
+import '../widgets/top_navbar.dart';
 
 class GroupScreen extends StatefulWidget {
   final String token;
@@ -113,8 +114,10 @@ class _GroupScreenState extends State<GroupScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Groups'),
+      appBar: TopNavBar(
+        token: widget.token,
+        title: 'Groups',
+        automaticallyImplyLeading: false,
       ),
       body: Column(
         children: [

--- a/frontend/lib/screens/invitations_screen.dart
+++ b/frontend/lib/screens/invitations_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/group_service.dart';
+import '../widgets/top_navbar.dart';
 
 class InvitationsScreen extends StatefulWidget {
   final String token;
@@ -91,7 +92,11 @@ class _InvitationsScreenState extends State<InvitationsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Invitations')),
+      appBar: TopNavBar(
+        token: widget.token,
+        title: 'Invitations',
+        automaticallyImplyLeading: false,
+      ),
       body: ListView.builder(
         itemCount: invitations.length,
         itemBuilder: (context, index) {

--- a/frontend/lib/screens/logged_in_screen.dart
+++ b/frontend/lib/screens/logged_in_screen.dart
@@ -34,7 +34,9 @@ class LoggedInScreen extends StatelessWidget {
     });
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Logged In')),
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+      ),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(16.0),

--- a/frontend/lib/screens/profile_screen.dart
+++ b/frontend/lib/screens/profile_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  final String token;
+
+  const ProfileScreen({super.key, required this.token});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: Center(
+        child: Text('Profile Page'),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/settings_screen.dart
+++ b/frontend/lib/screens/settings_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class SettingsScreen extends StatelessWidget {
+  final String token;
+
+  const SettingsScreen({super.key, required this.token});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: Center(
+        child: Text('Settings Page'),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/welcome_screen.dart
+++ b/frontend/lib/screens/welcome_screen.dart
@@ -8,7 +8,10 @@ class WelcomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Welcome')),
+      appBar: AppBar(
+        title: const Text('Welcome'),
+        automaticallyImplyLeading: false,
+      ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/frontend/lib/widgets/hamburger_menu.dart
+++ b/frontend/lib/widgets/hamburger_menu.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import '../screens/profile_screen.dart';
+import '../screens/settings_screen.dart';
+import '../screens/welcome_screen.dart';
+
+class HamburgerMenu extends StatelessWidget {
+  final String token;
+
+  const HamburgerMenu({super.key, required this.token});
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String>(
+      onSelected: (String value) {
+        switch (value) {
+          case 'Profile':
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => ProfileScreen(token: token),
+              ),
+            );
+            break;
+          case 'Settings':
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => SettingsScreen(token: token),
+              ),
+            );
+            break;
+          case 'Log Off':
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (context) => WelcomeScreen(),
+              ),
+            );
+            break;
+        }
+      },
+      itemBuilder: (BuildContext context) {
+        return {'Profile', 'Settings', 'Log Off'}.map((String choice) {
+          return PopupMenuItem<String>(
+            value: choice,
+            child: Text(choice),
+          );
+        }).toList();
+      },
+    );
+  }
+}

--- a/frontend/lib/widgets/navigation_widget.dart
+++ b/frontend/lib/widgets/navigation_widget.dart
@@ -4,16 +4,24 @@ import '../screens/invitations_screen.dart';
 
 class NavigationWidget extends StatefulWidget {
   final String token;
+  final int initialIndex;
 
-  const NavigationWidget({super.key, required this.token});
+  const NavigationWidget(
+      {super.key, required this.token, this.initialIndex = 0});
 
   @override
   _NavigationWidgetState createState() => _NavigationWidgetState();
 }
 
 class _NavigationWidgetState extends State<NavigationWidget> {
-  int _selectedIndex = 0;
+  late int _selectedIndex;
   int newInvitationsCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = widget.initialIndex;
+  }
 
   void _onItemTapped(int index) {
     setState(() {

--- a/frontend/lib/widgets/top_navbar.dart
+++ b/frontend/lib/widgets/top_navbar.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import '../widgets/hamburger_menu.dart';
+
+class TopNavBar extends StatelessWidget implements PreferredSizeWidget {
+  final String token;
+  final String title;
+  final bool automaticallyImplyLeading;
+
+  const TopNavBar({
+    super.key,
+    required this.token,
+    required this.title,
+    this.automaticallyImplyLeading = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: Text(title),
+      automaticallyImplyLeading: automaticallyImplyLeading,
+      actions: [
+        HamburgerMenu(token: token),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(kToolbarHeight);
+}


### PR DESCRIPTION
Closes #43 

Tämä pull request esittelee uuden TopNavBar-widgetin ja integroi sen eri näkymiin korvaamaan oletus AppBarin. Se lisää myös uusia näkymiä profiilille ja asetuksille sekä sisältää HamburgerMenu-widgetin navigointia varten.

**TopNavBarin integrointi:**

- **frontend/lib/screens/group_screen.dart:** Korvattu AppBar TopNavBarilla GroupScreenissä ja lisätty tarvittava import.
- **frontend/lib/screens/invitations_screen.dart:** Korvattu AppBar TopNavBarilla InvitationsScreenissä ja lisätty tarvittava import.

**Uudet näkymät:**

- **frontend/lib/screens/profile_screen.dart:** Lisätty ProfileScreen perus scaffoldilla ja app barilla.
- **frontend/lib/screens/settings_screen.dart:** Lisätty SettingsScreen perus scaffoldilla ja app barilla.

**Navigoinnin parannukset:**

- **frontend/lib/widgets/hamburger_menu.dart:** Esitelty HamburgerMenu-widget navigointia varten profiiliin, asetuksiin ja uloskirjautumiseen.
- **frontend/lib/widgets/navigation_widget.dart:** Muokattu NavigationWidget hyväksymään initialIndex-parametri ja alustamaan _selectedIndex vastaavasti.


**Muut muutokset:**

- **frontend/lib/screens/logged_in_screen.dart, frontend/lib/screens/welcome_screen.dart:** Päivitetty AppBar poistamaan johtava painike.
- **frontend/lib/widgets/top_navbar.dart:** Luotu TopNavBar-widget, joka sisältää otsikon ja HamburgerMenu-widgetin.