### PR TITLE
JWT Token Refresh

### DIFF
--- a/frontend/lib/screens/create_event_screen.dart
+++ b/frontend/lib/screens/create_event_screen.dart
@@ -22,7 +22,6 @@ class _CreateEventScreenState extends State<CreateEventScreen> {
   Future<void> _createEvent() async {
     try {
       final success = await _groupService.createEvent(
-        widget.token,
         widget.groupId,
         _titleController.text,
         _descriptionController.text,

--- a/frontend/lib/screens/create_group_screen.dart
+++ b/frontend/lib/screens/create_group_screen.dart
@@ -17,7 +17,6 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
 
   Future<void> _createGroup() async {
     final success = await _groupService.createGroup(
-      widget.token,
       _nameController.text,
       _descriptionController.text,
     );

--- a/frontend/lib/screens/event_detail_screen.dart
+++ b/frontend/lib/screens/event_detail_screen.dart
@@ -25,8 +25,8 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
 
   Future<void> fetchCreatorUsername() async {
     try {
-      final username = await _groupService.fetchCreatorUsername(
-          widget.token, widget.event['created_by']);
+      final username =
+          await _groupService.fetchCreatorUsername(widget.event['created_by']);
       setState(() {
         creatorUsername = username;
       });

--- a/frontend/lib/screens/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail_screen.dart
@@ -34,9 +34,8 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
   Future<void> fetchGroupDetails() async {
     try {
       final fetchedGroup =
-          await _groupService.fetchGroupDetails(widget.token, widget.groupId);
-      final members =
-          await _groupService.fetchGroupMembers(widget.token, widget.groupId);
+          await _groupService.fetchGroupDetails(widget.groupId);
+      final members = await _groupService.fetchGroupMembers(widget.groupId);
       debugPrint('Fetched group details: $fetchedGroup');
       setState(() {
         group = fetchedGroup;
@@ -53,7 +52,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
 
   Future<void> fetchCurrentUser() async {
     try {
-      await _groupService.fetchCurrentUser(widget.token);
+      await _groupService.fetchCurrentUser();
       setState(() {
         debugPrint('Current User ID: ${_groupService.currentUserId}');
       });

--- a/frontend/lib/screens/group_screen.dart
+++ b/frontend/lib/screens/group_screen.dart
@@ -90,23 +90,25 @@ class _GroupScreenState extends State<GroupScreen> {
 
   Future<void> fetchGroups() async {
     try {
-      final fetchedGroups = await _groupService.fetchGroups(widget.token);
+      final fetchedGroups = await _groupService.fetchGroups();
       setState(() {
         groups = fetchedGroups;
       });
     } catch (e) {
+      debugPrint('Error fetching groups: $e');
       // Handle error
     }
   }
 
   Future<void> fetchNewInvitationsCount() async {
     try {
-      final count = await _groupService.fetchNewInvitationsCount(widget.token);
+      final count = await _groupService.fetchNewInvitationsCount();
       setState(() {
         newInvitationsCount = count;
         widget.updateInvitationCount(count);
       });
     } catch (e) {
+      debugPrint('Error fetching invitations count: $e');
       // Handle error
     }
   }

--- a/frontend/lib/screens/group_settings_screen.dart
+++ b/frontend/lib/screens/group_settings_screen.dart
@@ -28,7 +28,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
 
   Future<void> fetchCurrentUserAndGroupDetails() async {
     try {
-      await _groupService.fetchCurrentUser(widget.token);
+      await _groupService.fetchCurrentUser();
       await fetchGroupDetails();
       await fetchCurrentUserRole();
     } catch (e) {
@@ -39,7 +39,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
   Future<void> fetchGroupDetails() async {
     try {
       final fetchedGroup =
-          await _groupService.fetchGroupDetails(widget.token, widget.groupId);
+          await _groupService.fetchGroupDetails(widget.groupId);
       debugPrint('Fetched group details: $fetchedGroup');
       setState(() {
         group = fetchedGroup;
@@ -53,8 +53,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
 
   Future<void> fetchCurrentUserRole() async {
     try {
-      final role = await _groupService.fetchCurrentUserRole(
-          widget.token, widget.groupId);
+      final role = await _groupService.fetchCurrentUserRole(widget.groupId);
       setState(() {
         currentUserRole = role;
       });
@@ -65,8 +64,8 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
 
   Future<void> _inviteUser() async {
     try {
-      final success = await _groupService.inviteUser(
-          widget.token, widget.groupId, _emailController.text);
+      final success =
+          await _groupService.inviteUser(widget.groupId, _emailController.text);
       if (success) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text('User invited successfully')));
@@ -82,7 +81,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
 
   Future<void> _kickUser(int membershipId) async {
     try {
-      final success = await _groupService.kickUser(widget.token, membershipId);
+      final success = await _groupService.kickUser(membershipId);
       if (success) {
         fetchGroupDetails();
         ScaffoldMessenger.of(context)
@@ -99,8 +98,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
 
   Future<void> _deleteGroup() async {
     try {
-      final success =
-          await _groupService.deleteGroup(widget.token, widget.groupId);
+      final success = await _groupService.deleteGroup(widget.groupId);
       if (success) {
         Navigator.of(context).pop(true);
         ScaffoldMessenger.of(context).showSnackBar(
@@ -117,8 +115,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
 
   Future<void> _leaveGroup() async {
     try {
-      final success =
-          await _groupService.leaveGroup(widget.token, widget.groupId);
+      final success = await _groupService.leaveGroup(widget.groupId);
       if (success) {
         Navigator.of(context).pop(true);
         ScaffoldMessenger.of(context).showSnackBar(
@@ -190,8 +187,7 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
   }
 
   void _showKickUserDialog() async {
-    final members =
-        await _groupService.fetchGroupMembers(widget.token, widget.groupId);
+    final members = await _groupService.fetchGroupMembers(widget.groupId);
     final nonAdminMembers =
         members.where((member) => member['role'] != 'admin').toList();
     showDialog(

--- a/frontend/lib/screens/invitations_screen.dart
+++ b/frontend/lib/screens/invitations_screen.dart
@@ -25,8 +25,7 @@ class _InvitationsScreenState extends State<InvitationsScreen> {
 
   Future<void> fetchInvitations() async {
     try {
-      final fetchedInvitations =
-          await _groupService.fetchInvitations(widget.token);
+      final fetchedInvitations = await _groupService.fetchInvitations();
       setState(() {
         invitations = fetchedInvitations;
       });
@@ -41,8 +40,7 @@ class _InvitationsScreenState extends State<InvitationsScreen> {
 
   Future<void> _acceptInvitation(int invitationId) async {
     try {
-      final success =
-          await _groupService.acceptInvitation(widget.token, invitationId);
+      final success = await _groupService.acceptInvitation(invitationId);
       if (success) {
         setState(() {
           invitations
@@ -66,8 +64,7 @@ class _InvitationsScreenState extends State<InvitationsScreen> {
 
   Future<void> _rejectInvitation(int invitationId) async {
     try {
-      final success =
-          await _groupService.rejectInvitation(widget.token, invitationId);
+      final success = await _groupService.rejectInvitation(invitationId);
       if (success) {
         setState(() {
           invitations

--- a/frontend/lib/services/group_service.dart
+++ b/frontend/lib/services/group_service.dart
@@ -2,18 +2,31 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter/foundation.dart';
+import 'auth_service.dart';
 
 class GroupService {
   final String baseUrl = dotenv.env['BASE_URL']!;
   int? currentUserId;
+  final AuthService _authService = AuthService();
 
-  Future<List<dynamic>> fetchGroups(String token) async {
+  Future<List<dynamic>> fetchGroups() async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      debugPrint('No valid token available');
+      throw Exception('No valid token available');
+    }
+
+    debugPrint('Using token: $token');
+
     final response = await http.get(
       Uri.parse('$baseUrl/groups/'),
       headers: {
         'Authorization': 'Bearer $token',
       },
     );
+
+    debugPrint('Response status: ${response.statusCode}');
+    debugPrint('Response body: ${response.body}');
 
     if (response.statusCode == 200) {
       return json.decode(response.body);
@@ -22,8 +35,12 @@ class GroupService {
     }
   }
 
-  Future<bool> createGroup(
-      String token, String name, String description) async {
+  Future<bool> createGroup(String name, String description) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final response = await http.post(
       Uri.parse('$baseUrl/groups/'),
       headers: {
@@ -44,8 +61,13 @@ class GroupService {
     }
   }
 
-  Future<Map<String, dynamic>> fetchGroupDetails(
-      String token, int groupId) async {
+  Future<Map<String, dynamic>> fetchGroupDetails(int groupId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      debugPrint('No valid token available');
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/$groupId/');
     final response = await http.get(
       url,
@@ -53,6 +75,9 @@ class GroupService {
         'Authorization': 'Bearer $token',
       },
     );
+
+    debugPrint('Response status: ${response.statusCode}');
+    debugPrint('Response body: ${response.body}');
 
     if (response.statusCode == 200) {
       final groupData = json.decode(response.body);
@@ -63,7 +88,13 @@ class GroupService {
     }
   }
 
-  Future<List<dynamic>> fetchGroupMembers(String token, int groupId) async {
+  Future<List<dynamic>> fetchGroupMembers(int groupId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      debugPrint('No valid token available');
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/$groupId/members/');
     final response = await http.get(
       url,
@@ -71,6 +102,9 @@ class GroupService {
         'Authorization': 'Bearer $token',
       },
     );
+
+    debugPrint('Response status: ${response.statusCode}');
+    debugPrint('Response body: ${response.body}');
 
     if (response.statusCode == 200) {
       final membersData = json.decode(response.body);
@@ -81,13 +115,22 @@ class GroupService {
     }
   }
 
-  Future<List<dynamic>> fetchGroupEvents(String token, int groupId) async {
+  Future<List<dynamic>> fetchGroupEvents(int groupId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      debugPrint('No valid token available');
+      throw Exception('No valid token available');
+    }
+
     final response = await http.get(
       Uri.parse('$baseUrl/groups/$groupId/events/'),
       headers: {
         'Authorization': 'Bearer $token',
       },
     );
+
+    debugPrint('Response status: ${response.statusCode}');
+    debugPrint('Response body: ${response.body}');
 
     if (response.statusCode == 200) {
       return json.decode(response.body);
@@ -96,13 +139,19 @@ class GroupService {
     }
   }
 
-  Future<bool> createEvent(String token, int groupId, String title,
-      String description, DateTime startTime, DateTime endTime) async {
-    final url = Uri.parse('$baseUrl/groups/events/create/');
+  Future<bool> createEvent(int groupId, String title, String description,
+      DateTime startTime, DateTime endTime) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
+    final url = '$baseUrl/groups/events/create/';
     debugPrint(
         'Sending POST request to $url with data: {group: $groupId, title: $title, description: $description, start_time: ${startTime.toIso8601String()}, end_time: ${endTime.toIso8601String()}}');
+
     final response = await http.post(
-      url,
+      Uri.parse(url),
       headers: {
         'Authorization': 'Bearer $token',
         'Content-Type': 'application/json',
@@ -125,7 +174,12 @@ class GroupService {
     }
   }
 
-  Future<bool> inviteUser(String token, int groupId, String email) async {
+  Future<bool> inviteUser(int groupId, String email) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/invite/');
     debugPrint(
         'Sending POST request to $url with data: {group_id: $groupId, email: $email}');
@@ -150,7 +204,12 @@ class GroupService {
     }
   }
 
-  Future<List<dynamic>> fetchInvitations(String token) async {
+  Future<List<dynamic>> fetchInvitations() async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final response = await http.get(
       Uri.parse('$baseUrl/groups/invitations/'),
       headers: {
@@ -165,7 +224,12 @@ class GroupService {
     }
   }
 
-  Future<bool> acceptInvitation(String token, int invitationId) async {
+  Future<bool> acceptInvitation(int invitationId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final response = await http.post(
       Uri.parse('$baseUrl/groups/invite/accept/'),
       headers: {
@@ -185,7 +249,12 @@ class GroupService {
     }
   }
 
-  Future<bool> rejectInvitation(String token, int invitationId) async {
+  Future<bool> rejectInvitation(int invitationId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final response = await http.post(
       Uri.parse('$baseUrl/groups/invite/reject/'),
       headers: {
@@ -205,7 +274,12 @@ class GroupService {
     }
   }
 
-  Future<bool> kickUser(String token, int membershipId) async {
+  Future<bool> kickUser(int membershipId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/kick/$membershipId/');
     final response = await http.delete(
       url,
@@ -223,7 +297,12 @@ class GroupService {
     }
   }
 
-  Future<void> fetchCurrentUser(String token) async {
+  Future<void> fetchCurrentUser() async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/accounts/me/');
     final response = await http.get(
       url,
@@ -242,7 +321,12 @@ class GroupService {
     }
   }
 
-  Future<String?> fetchCurrentUserRole(String token, int groupId) async {
+  Future<String?> fetchCurrentUserRole(int groupId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/$groupId/members/');
     final response = await http.get(
       url,
@@ -262,7 +346,12 @@ class GroupService {
     }
   }
 
-  Future<bool> deleteGroup(String token, int groupId) async {
+  Future<bool> deleteGroup(int groupId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/$groupId/delete/');
     final response = await http.delete(
       url,
@@ -280,7 +369,12 @@ class GroupService {
     }
   }
 
-  Future<int> fetchNewInvitationsCount(String token) async {
+  Future<int> fetchNewInvitationsCount() async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/invitations/count/');
     final response = await http.get(
       url,
@@ -297,7 +391,12 @@ class GroupService {
     }
   }
 
-  Future<bool> leaveGroup(String token, int groupId) async {
+  Future<bool> leaveGroup(int groupId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/groups/leave/');
     final response = await http.post(
       url,
@@ -315,7 +414,12 @@ class GroupService {
     }
   }
 
-  Future<String?> fetchCreatorUsername(String token, int userId) async {
+  Future<String?> fetchCreatorUsername(int userId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
     final url = Uri.parse('$baseUrl/accounts/user/$userId/');
     final response = await http.get(
       url,


### PR DESCRIPTION
Closes #46

Tässä pull requestissa on toteutettu JWT-tokenin automaattinen päivitystoiminnallisuus, joka parantaa sovelluksen turvallisuutta ja käyttökokemusta. Uudistus on lisätty auth_service.dart-tiedostoon, ja sen myötä kaikki group_service.dart-tiedoston metodit on päivitetty käyttämään tätä uutta toiminnallisuutta.

- `AuthService`-luokka toteutettiin singleton-mallilla varmistaaksemme, että sama instanssi on käytössä koko sovelluksessa ja että tokenit säilyvät oikein.
- `loginUser` ja `registerUser` -metodit asettavat kirjautumisen yhteydessä sekä `accessToken`- että `refreshToken`-tokenit.
- `refreshAccessToken`-metodi päivittää `accessToken`-tokenin käyttäen `refreshToken`-tokenia.
- `getValidToken`-metodi tarkistaa `accessToken`-tokenin voimassaolon ja päivittää sen tarvittaessa automaattisesti.
- Kaikki `group_service.dart`-tiedoston metodit on päivitetty käyttämään `getValidToken`-metodia. Tämä varmistaa, että jokaisella API-kutsulla on voimassa oleva token, mikä ehkäisee virhetilanteita vanhentuneiden tokenien vuoksi.