### PR TITLE
WebSocket aktiivisena

### DIFF
--- a/frontend/lib/services/websocket_service.dart
+++ b/frontend/lib/services/websocket_service.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:web_socket_channel/io.dart';
+import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
+
+class WebSocketService {
+  late WebSocketChannel _channel;
+  bool _isConnected = false;
+  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+  Function? onNewInvitation;
+  final AuthService _authService = AuthService();
+
+  WebSocketService() {
+    _initializeNotifications();
+  }
+
+  void _initializeNotifications() {
+    const AndroidInitializationSettings initializationSettingsAndroid =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+
+    const InitializationSettings initializationSettings =
+        InitializationSettings(
+      android: initializationSettingsAndroid,
+    );
+
+    flutterLocalNotificationsPlugin.initialize(initializationSettings);
+  }
+
+  void connect() async {
+    if (_isConnected) return;
+
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      debugPrint('No valid token available for WebSocket');
+      return;
+    }
+
+    final uri =
+        Uri.parse('ws://192.168.1.211:8000/ws/notifications/?token=$token');
+    _channel = IOWebSocketChannel.connect(uri);
+
+    _channel.stream.listen((message) async {
+      debugPrint("Received message: $message");
+      final data = json.decode(message);
+      debugPrint('Received WebSocket message: $data');
+
+      if (data != null &&
+          data.containsKey('title') &&
+          data.containsKey('body')) {
+        // Handle WebSocket messages here
+        if (data['title'] == 'New Invitation') {
+          // Show a local notification
+          const AndroidNotificationDetails androidPlatformChannelSpecifics =
+              AndroidNotificationDetails(
+            'group_invites_channel', // channelId
+            'Group Invites', // channelName
+            channelDescription:
+                'Notifications for group invites', // description
+            importance: Importance.max,
+            priority: Priority.high,
+            ticker: 'ticker',
+          );
+
+          const NotificationDetails platformChannelSpecifics =
+              NotificationDetails(android: androidPlatformChannelSpecifics);
+
+          await flutterLocalNotificationsPlugin.show(
+            0, // Notification ID
+            data['title'], // Notification title
+            data['body'], // Notification body
+            platformChannelSpecifics,
+          );
+
+          // Call the callback function if set
+          if (onNewInvitation != null) {
+            onNewInvitation!();
+          }
+        }
+      } else {
+        debugPrint('Received invalid WebSocket message: $data');
+      }
+    }, onDone: () {
+      debugPrint('WebSocket connection closed');
+      _isConnected = false;
+    }, onError: (error) {
+      debugPrint('WebSocket error: $error');
+      _isConnected = false;
+    });
+
+    _isConnected = true;
+    debugPrint('WebSocket connected');
+  }
+
+  void disconnect() {
+    if (_isConnected) {
+      _channel.sink.close();
+      _isConnected = false;
+      debugPrint('WebSocket disconnected');
+    }
+  }
+
+  WebSocketChannel get channel => _channel;
+}


### PR DESCRIPTION
Closes #58 

Tämä pull request sisältää merkittäviä muutoksia GroupScreen- ja NavigationWidget-komponenttien WebSocket-käsittelyyn sekä uuden WebSocketServicen käyttöönoton WebSocket-yhteyksien ja ilmoitusten hallintaan. Muutosten tavoitteena on parantaa koodipohjan modulaarisuutta ja ylläpidettävyyttä.

### Keskeiset muutokset:

#### Parannuksia WebSocket-käsittelyyn:
- **frontend/lib/screens/group_screen.dart**: Poistettu suora WebSocket-yhteys ja ilmoitusten käsittely GroupScreen-komponentista. Tilalle lisättiin uusi WebSocketService, mikä yksinkertaistaa GroupScreen-komponenttia ja siirtää WebSocket-vastuut palvelulle.

#### WebSocketServicen käyttöönotto:
- **frontend/lib/services/websocket_service.dart**: Lisätty uusi `WebSocketService`-luokka WebSocket-yhteyksien hallintaan, ilmoitusten käsittelyyn ja uusien kutsujen callback-mekanismin tarjoamiseen. Tämä palvelu kapseloi WebSocket-logiikan, tehden siitä uudelleenkäytettävän ja helpommin hallittavan.

#### Integrointi NavigationWidget-komponenttiin:
- **frontend/lib/widgets/navigation_widget.dart**: Integroitu WebSocketService NavigationWidget-komponenttiin, varmistaen, että WebSocket-yhteys luodaan ja hallitaan korkeammalla tasolla komponenttihierarkiassa. Tämä mahdollistaa paremman resurssien hallinnan ja koordinoinnin sovelluksen eri osien välillä.
