### PR TITLE
Ryhmäkeskustelu Frontend

### DIFF
--- a/backend/backend/consumers.py
+++ b/backend/backend/consumers.py
@@ -72,7 +72,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
             {
                 'type': 'chat_message',
                 'message': chat_message.message,
-                'user': chat_message.user.username,
+                'user': chat_message.user.id,  # Send user ID instead of username
                 'timestamp': chat_message.timestamp.isoformat(),
             }
         )
@@ -80,7 +80,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
     async def chat_message(self, event):
         await self.send(text_data=json.dumps({
             'message': event['message'],
-            'user': event['user'],
+            'user': event['user'],  # Ensure user ID is sent
             'timestamp': event['timestamp'],
         }))
 

--- a/backend/groups/serializers.py
+++ b/backend/groups/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Group, GroupMembership, Event, GroupInvitation
+from .models import Group, GroupMembership, Event, GroupInvitation, ChatMessage
 from django.contrib.auth.models import User
 
 class UserSerializer(serializers.ModelSerializer):
@@ -40,3 +40,11 @@ class GroupInvitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = GroupInvitation
         fields = '__all__'
+
+class ChatMessageSerializer(serializers.ModelSerializer):
+    user = serializers.PrimaryKeyRelatedField(read_only=True)
+    group = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = ChatMessage
+        fields = ['id', 'group', 'user', 'message', 'timestamp']

--- a/backend/groups/urls.py
+++ b/backend/groups/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from .views import (
-    DeleteGroupView, GroupListCreateView, GroupDetailView, GroupMembersView,
+    ChatMessageListView, DeleteGroupView, GroupListCreateView, GroupDetailView, GroupMembersView,
     GroupMembershipListCreateView, GroupMembershipDetailView,
     EventListCreateView, EventDetailView, EventCreateView, InviteUserView, AcceptInvitationView, KickUserView, LeaveGroupView, NewInvitationsCountView, RejectInvitationView, ListInvitationsView
 )
@@ -22,4 +22,5 @@ urlpatterns = [
     path('<int:pk>/members/', GroupMembersView.as_view(), name='group-members'),
     path('invitations/count/', NewInvitationsCountView.as_view(), name='new-invitations-count'),
     path('leave/', LeaveGroupView.as_view(), name='leave-group'),
+    path('<int:group_id>/chat/', ChatMessageListView.as_view(), name='chat-message-list'),
 ]

--- a/backend/groups/views.py
+++ b/backend/groups/views.py
@@ -1,8 +1,8 @@
 from rest_framework import generics, status
-from .models import Group, GroupMembership, Event, GroupInvitation
+from .models import Group, GroupMembership, Event, GroupInvitation, ChatMessage
 from django.db import models
 from django.contrib.auth.models import User
-from .serializers import GroupSerializer, GroupMembershipSerializer, EventSerializer, GroupInvitationSerializer
+from .serializers import GroupSerializer, GroupMembershipSerializer, EventSerializer, GroupInvitationSerializer, ChatMessageSerializer
 from rest_framework.response import Response
 import logging
 from rest_framework.permissions import IsAuthenticated
@@ -221,3 +221,11 @@ class LeaveGroupView(APIView):
             return Response({'error': 'Membership not found.'}, status=status.HTTP_404_NOT_FOUND)
         except Exception as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        
+class ChatMessageListView(generics.ListAPIView):
+    serializer_class = ChatMessageSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        group_id = self.kwargs['group_id']
+        return ChatMessage.objects.filter(group_id=group_id).order_by('timestamp')

--- a/frontend/lib/screens/chat_screen.dart
+++ b/frontend/lib/screens/chat_screen.dart
@@ -1,19 +1,186 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:web_socket_channel/io.dart';
+import '../services/group_service.dart';
 
-class ChatScreen extends StatelessWidget {
+class ChatScreen extends StatefulWidget {
   final String token;
+  final int groupId;
 
-  const ChatScreen({super.key, required this.token});
+  ChatScreen({required this.token, required this.groupId});
+
+  @override
+  _ChatScreenState createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  late WebSocketChannel _channel;
+  final TextEditingController _controller = TextEditingController();
+  final List<Map<String, dynamic>> _messages = [];
+  final GroupService _groupService = GroupService();
+  final Map<int, String> _usernamesCache = {};
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchChatMessages();
+    _connectToChat();
+  }
+
+  void _connectToChat() {
+    final uri = Uri.parse(
+        'ws://192.168.1.211:8000/ws/chat/${widget.groupId}/?token=${widget.token}');
+    _channel = IOWebSocketChannel.connect(uri);
+
+    _channel.stream.listen((message) {
+      final data = json.decode(message);
+      setState(() {
+        _messages.add(data);
+      });
+      _scrollToBottom();
+    }, onDone: () {
+      debugPrint('WebSocket chat connection closed');
+    }, onError: (error) {
+      debugPrint('WebSocket chat error: $error');
+    });
+  }
+
+  void _sendMessage() {
+    if (_controller.text.isNotEmpty) {
+      final message = {'message': _controller.text};
+      _channel.sink.add(json.encode(message));
+      _controller.clear();
+    }
+  }
+
+  Future<void> _fetchChatMessages() async {
+    try {
+      final messages = await _groupService.fetchChatMessages(widget.groupId);
+      setState(() {
+        _messages.addAll(messages);
+      });
+      _scrollToBottom();
+    } catch (e) {
+      debugPrint('Error fetching chat messages: $e');
+    }
+  }
+
+  Future<String> _fetchUsername(int userId) async {
+    if (_usernamesCache.containsKey(userId)) {
+      return _usernamesCache[userId]!;
+    }
+    try {
+      final user = await _groupService.fetchUserDetails(userId);
+      _usernamesCache[userId] = user['username'];
+      return user['username'];
+    } catch (e) {
+      debugPrint('Error fetching username: $e');
+      return 'Unknown';
+    }
+  }
+
+  String _formatTimestamp(String timestamp) {
+    return DateTime.parse(timestamp).toLocal().toString();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _channel.sink.close();
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        automaticallyImplyLeading: false, // Remove the back arrow icon
+        title: Text('Chat'),
       ),
-      body: Center(
-        child: Text('Chat Screen'),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              controller: _scrollController,
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final message = _messages[index];
+                final userId = message['user'];
+                if (userId is String) {
+                  debugPrint('Error: userId is a String: $userId');
+                  // Attempt to parse the userId as an integer
+                  try {
+                    final parsedUserId = int.parse(userId);
+                    return _buildMessageTile(message, parsedUserId);
+                  } catch (e) {
+                    debugPrint('Failed to parse userId: $e');
+                    return ListTile(
+                      title: Text('Error'),
+                      subtitle: Text(message['message']),
+                    );
+                  }
+                } else if (userId is int) {
+                  debugPrint('userId is an int: $userId');
+                  return _buildMessageTile(message, userId);
+                } else {
+                  debugPrint('Unexpected userId type: ${userId.runtimeType}');
+                  return ListTile(
+                    title: Text('Error'),
+                    subtitle: Text(message['message']),
+                  );
+                }
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: InputDecoration(
+                      hintText: 'Enter your message',
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.send),
+                  onPressed: _sendMessage,
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
+    );
+  }
+
+  Widget _buildMessageTile(Map<String, dynamic> message, int userId) {
+    return FutureBuilder<String>(
+      future: _fetchUsername(userId),
+      builder: (context, snapshot) {
+        final username = snapshot.data ?? 'Loading...';
+        final formattedTimestamp = _formatTimestamp(message['timestamp']);
+        return ListTile(
+          title: Text(username),
+          subtitle: Text(message['message']),
+          trailing: Text(formattedTimestamp),
+        );
+      },
     );
   }
 }

--- a/frontend/lib/screens/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail_screen.dart
@@ -134,7 +134,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
           ),
         ],
       ),
-      ChatScreen(token: widget.token),
+      ChatScreen(token: widget.token, groupId: widget.groupId),
     ];
 
     return Scaffold(

--- a/frontend/lib/services/group_service.dart
+++ b/frontend/lib/services/group_service.dart
@@ -435,4 +435,46 @@ class GroupService {
       throw Exception('Failed to fetch creator username');
     }
   }
+
+  Future<Map<String, dynamic>> fetchUserDetails(int userId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
+    final url = Uri.parse('$baseUrl/accounts/user/$userId/');
+    final response = await http.get(
+      url,
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      return json.decode(response.body);
+    } else {
+      throw Exception('Failed to fetch user details');
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> fetchChatMessages(int groupId) async {
+    final token = await _authService.getValidToken();
+    if (token == null) {
+      throw Exception('No valid token available');
+    }
+
+    final url = Uri.parse('$baseUrl/groups/$groupId/chat/');
+    final response = await http.get(
+      url,
+      headers: {
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      return List<Map<String, dynamic>>.from(json.decode(response.body));
+    } else {
+      throw Exception('Failed to fetch chat messages');
+    }
+  }
 }


### PR DESCRIPTION
Closes #61 

Tämä pull request tuo kattavan ryhmäkeskustelun toiminnallisuuden, johon sisältyy muutoksia sekä backend- että frontend-puolella. Keskeiset muutokset koskevat serializerien, näkymien ja URL-osoitteiden päivityksiä backendissä sekä WebSocket-yhteyksien ja viestien käsittelyn toteuttamista frontendissä.

**Backend-muutokset:**

- Päivitetty `backend/groups/serializers.py` sisällyttämään `ChatMessageSerializer` keskusteluviestien serialisointia varten.

- Lisätty `ChatMessageListView` tiedostoon `backend/groups/views.py` keskusteluviestien listaamisen hallintaan tietylle ryhmälle.

- Muokattu `backend/groups/urls.py` lisäämään uusi URL-polku ryhmän keskusteluviestien noutamista varten.

**Frontend-muutokset:**

- Parannettu `ChatScreen` tiedostossa `frontend/lib/screens/chat_screen.dart` hallitsemaan WebSocket-yhteyksiä reaaliaikaista viestintää varten sekä noutamaan keskusteluviestit palvelimelta.

- Päivitetty `GroupDetailScreen` välittämään groupId `ChatScreen`-komponentille ryhmäkohtaisen keskustelutoiminnon mahdollistamiseksi.

- Lisätty `GroupService`-luokkaan metodit käyttäjätietojen ja keskusteluviestien noutamista varten backendistä.

**Muut muutokset:**

- Päivitetty `backend/backend/consumers.py` lähettämään käyttäjän ID:n käyttäjänimen sijaan keskusteluviesteissä johdonmukaisuuden takaamiseksi.