### PR TITLE
Frontend parannukset ChatScreenille

### DIFF
--- a/frontend/lib/services/auth_service.dart
+++ b/frontend/lib/services/auth_service.dart
@@ -117,4 +117,24 @@ class AuthService {
         utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
     return json.decode(payload);
   }
+
+  int extractUserIdFromToken(String token) {
+    try {
+      final parts = token.split('.');
+      if (parts.length != 3) {
+        throw Exception('Invalid token');
+      }
+      final payload =
+          utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
+      final payloadMap = json.decode(payload);
+      if (payloadMap.containsKey('user_id')) {
+        return payloadMap['user_id'];
+      } else {
+        throw Exception('user_id not found in token');
+      }
+    } catch (e) {
+      debugPrint('Error extracting user ID from token: $e');
+      throw Exception('Failed to extract user ID from token');
+    }
+  }
 }

--- a/frontend/lib/widgets/message_bubble.dart
+++ b/frontend/lib/widgets/message_bubble.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class MessageBubble extends StatelessWidget {
+  final String message;
+  final String username;
+  final String timestamp;
+  final bool isMe;
+
+  MessageBubble({
+    required this.message,
+    required this.username,
+    required this.timestamp,
+    required this.isMe,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: isMe ? Alignment.centerRight : Alignment.centerLeft,
+      child: FractionallySizedBox(
+        widthFactor: 0.9, // 90% of the available width
+        child: Container(
+          margin: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+          padding: EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: isMe ? Colors.blueAccent : Colors.grey[300],
+            borderRadius: BorderRadius.circular(15),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                username,
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  color: isMe ? Colors.white : Colors.black,
+                ),
+              ),
+              SizedBox(height: 5),
+              Text(
+                message,
+                style: TextStyle(
+                  color: isMe ? Colors.white : Colors.black,
+                ),
+              ),
+              SizedBox(height: 5),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  timestamp,
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: isMe ? Colors.white70 : Colors.black54,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Closes #64 

Tässä pull requestissa on useita parannuksia ja uusia ominaisuuksia chat-näytön käyttöliittymään sekä uusi funktio käyttäjän ID:n poimimiseksi JWT-tokenista.


**chat_screen.dart**
- AppBar poistettiin, jotta saataisiin siistimpi ulkoasu, koska alareunan navigointipalkkia käytetään navigointiin.
- Integroitiin uusi funktio tiedostosta auth_service.dart käyttäjän ID:n poimimiseksi JWT-tokenista, mikä varmistaa viestikuplien oikean kohdistuksen lähettäjän perusteella.
- Päivitettiin chat-näyttö käyttämään uutta MessageBubble-widgettiä viestien näyttämiseksi yhtenäisessä kuplamuodossa.

**message_bubble.dart**
- Luotiin uusi MessageBubble-widget viestien näyttämiseksi kuplamuodossa.
- Kuplat kohdistetaan oikealle nykyisen käyttäjän viesteille ja vasemmalle muiden käyttäjien viesteille.
  - Käyttäjänimi ja viestiteksti ovat vasemmalle kohdistettuja, kun taas aikaleima on oikealle kohdistettu.
- Kuplilla on kiinteä leveys, joka on 90% näytön leveydestä, mikä varmistaa yhtenäisen ulkoasun.

**auth_service.dart**
- Lisättiin uusi funktio extractUserIdFromToken käyttäjän ID:n poimimiseksi JWT-tokenista.