### PR TITLE
Invite User UI parannukset

### DIFF
--- a/frontend/lib/screens/group_settings_screen.dart
+++ b/frontend/lib/screens/group_settings_screen.dart
@@ -266,6 +266,36 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
     );
   }
 
+  void _showInviteUserDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Invite User'),
+          content: TextField(
+            controller: _emailController,
+            decoration: InputDecoration(labelText: 'Email'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _inviteUser();
+              },
+              child: Text('Invite'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isAdmin = currentUserRole == 'admin';
@@ -278,13 +308,18 @@ class _GroupSettingsScreenState extends State<GroupSettingsScreen> {
               padding: const EdgeInsets.all(16.0),
               child: Column(
                 children: [
-                  TextField(
-                    controller: _emailController,
-                    decoration: InputDecoration(labelText: 'Email'),
-                  ),
+                  if (group != null) ...[
+                    Text(
+                      group!['name'],
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
                   SizedBox(height: 20),
                   ElevatedButton(
-                    onPressed: _inviteUser,
+                    onPressed: _showInviteUserDialog,
                     child: Text('Invite User'),
                   ),
                   if (isAdmin) ...[


### PR DESCRIPTION
Closes #68 

Tässä pull requestissa tehdään parannuksia GroupSettingsScreen-näkymään tiedostossa group_settings_screen.dart refaktoroimalla käyttäjien kutsumisprosessi. Pääasialliset muutokset sisältävät dialogin lisäämisen käyttäjien kutsumista varten ja käyttöliittymän päivittämisen näyttämään ryhmän nimen setting screenissä.

**Parannukset käyttäjien kutsumisprosessiin:**
- Lisätty _showInviteUserDialog-metodi näyttämään dialogin käyttäjien kutsumista varten, joka sisältää tekstikentän sähköpostin syöttämistä varten sekä painikkeet kutsun peruuttamiseen tai lähettämiseen.

**Käyttöliittymän parannukset:**
- Päivitetty käyttöliittymä näyttämään ryhmän nimi, jos ryhmän tiedot ovat saatavilla.
- Muutettu 'Invite User' -painikkeen onPressed-käsittelijä avaamaan uusi käyttäjän kutsumisdialogi sen sijaan, että kutsuttaisiin suoraan _inviteUser-metodia.